### PR TITLE
fix: 'get_active_interface' MacOS Issue

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -19,23 +19,25 @@ function trim_exec(cmd, cb) {
 
 function determine_nic_type(str) {
   return str.match(/Ethernet/)
-         ? 'Wired'
-         : str.match(/Wi-?Fi|AirPort/i)
-           ? 'Wireless'
-           : str.match(/FireWire/)
-             ? 'FireWire'
-             : str.match(/Thunderbolt/)
-               ? 'Thunderbolt'
-               : str.match(/Bluetooth/)
-                 ? 'Bluetooth'
-                 : 'Other';
+    ? "Wired"
+    : str.match(/Wi-?Fi|AirPort/i)
+    ? "Wireless"
+    : str.match(/FireWire/)
+    ? "FireWire"
+    : str.match(/Thunderbolt/)
+    ? "Thunderbolt"
+    : str.match(/Bluetooth/)
+    ? "Bluetooth"
+    : str.match(/USB 10\/100\/1000 LAN/)
+    ? "USB Ethernet Adapter"
+    : "Other";
 }
 
 //////////////////////////////////////////
 // exports
 
 exports.get_active_network_interface_name = function(cb) {
-  var cmd = "netstat -rn | grep UG | awk '{print $6}'";
+  var cmd = "netstat -rn | grep UG | awk '{print $NF}'";
   exec(cmd, function(err, stdout) {
     if (err) return cb(err);
 


### PR DESCRIPTION
    Issue:
    - get_active_interface would throw 'No active interfaces detected' when connected using USB 10/100/1000 LAN Ethernet Adapter on MacOS.

    fix:
    - Modified 'get_active_network_interface_name' command to use $NF instead of $6, in order to print the last column instead of the 6th, which seems to no longer exist.

    - Added 'USB Ethernet Adapter' option to 'determine_nic_type'.